### PR TITLE
Update install_tracked for newer versions of Moo, fix roles

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -29,6 +29,7 @@ remove = strict
 remove = warnings
 remove = lib
 remove = Moo::Role
+remove = Moo::_Utils
 remove = File::Spec
 remove = Test::More
 

--- a/lib/MooX/Should.pm
+++ b/lib/MooX/Should.pm
@@ -18,7 +18,7 @@ BEGIN {
 
 use Devel::StrictMode;
 
-our $VERSION = 'v0.1.3';
+our $VERSION = version->declare('v0.1.3');
 
 sub import {
     my ($class) = @_;

--- a/lib/MooX/Should.pm
+++ b/lib/MooX/Should.pm
@@ -2,8 +2,19 @@ package MooX::Should;
 
 # ABSTRACT: optional type restrictions for Moo attributes
 
+use version 0.77 ();
+
 use Moo       ();
 use Moo::Role ();
+
+our $USE_MOO_UTILS;
+
+BEGIN {
+    if( version->parse( Moo->VERSION ) >= version->parse('2.003006') ) {
+        $USE_MOO_UTILS = 1;
+        require Moo::_Utils;
+    }
+}
 
 use Devel::StrictMode;
 
@@ -15,9 +26,11 @@ sub import {
     my $target = caller;
 
     my $installer =
-      $target->isa("Moo::Object")
-      ? \&Moo::_install_tracked
-      : \&Moo::Role::install_tracked;
+      $USE_MOO_UTILS
+      ? \&Moo::_Utils::_install_tracked
+      : $target->isa("Moo::Object")
+          ? \&Moo::_install_tracked
+          : \&Moo::Role::install_tracked;
 
     if ( my $has = $target->can('has') ) {
 

--- a/lib/MooX/Should.pm
+++ b/lib/MooX/Should.pm
@@ -30,7 +30,7 @@ sub import {
       ? \&Moo::_Utils::_install_tracked
       : $target->isa("Moo::Object")
           ? \&Moo::_install_tracked
-          : \&Moo::Role::install_tracked;
+          : \&Moo::Role::_install_tracked;
 
     if ( my $has = $target->can('has') ) {
 

--- a/t/03-role.t
+++ b/t/03-role.t
@@ -1,0 +1,18 @@
+BEGIN {
+    $ENV{PERL_STRICT} = 1;
+}
+
+use Test::Most;
+
+use lib 't/lib';
+use TestClass;
+use Moo::Role ();
+
+TODO: { local $TODO = 'Not able to use role with MooX::Should: dies due to missing installer function';
+lives_ok {
+    my $class_with_role = Moo::Role->create_class_with_roles( 'TestClass', 'TestRole' );
+    $class_with_role->new( c => 1 );
+} 'use role with MooX::Should';
+}
+
+done_testing;

--- a/t/03-role.t
+++ b/t/03-role.t
@@ -8,11 +8,9 @@ use lib 't/lib';
 use TestClass;
 use Moo::Role ();
 
-TODO: { local $TODO = 'Not able to use role with MooX::Should: dies due to missing installer function';
 lives_ok {
     my $class_with_role = Moo::Role->create_class_with_roles( 'TestClass', 'TestRole' );
     $class_with_role->new( c => 1 );
 } 'use role with MooX::Should';
-}
 
 done_testing;

--- a/t/lib/TestRole.pm
+++ b/t/lib/TestRole.pm
@@ -1,0 +1,15 @@
+package TestRole;
+
+use Moo::Role;
+use MooX::Should;
+
+use Types::Standard qw/ Int /;
+
+use namespace::autoclean;
+
+has c => (
+    is     => 'ro',
+    should => Int,
+);
+
+1;


### PR DESCRIPTION
Use `_install_tracked` from `Moo::_Utils` directly
    
This allows for roles to work again with newer versions of Moo as
`_install_tracked` is shared as an API for both `Moo` and `Moo::Role`.
See <https://github.com/moose/Moo/commit/a72639a9b6259e487e0cf496cf9d8d097e62ab39>
for more info. Available since Moo-2.003006.
